### PR TITLE
Convert colors to rgba

### DIFF
--- a/zathurarc
+++ b/zathurarc
@@ -32,8 +32,8 @@ set inputbar-fg                 "#f8f8f2" # Foreground
 set statusbar-bg                "#282a36" # Background
 set statusbar-fg                "#f8f8f2" # Foreground
 
-set highlight-color             "#ffb86c" # Orange
-set highlight-active-color      "#ff79c6" # Pink
+set highlight-color             rgba(255,184,108,0.5) # Orange
+set highlight-active-color      rgba(255,121,198,0.5) # Pink
 
 set default-bg                  "#282a36" # Background
 set default-fg                  "#f8f8f2" # Foreground

--- a/zathurarc
+++ b/zathurarc
@@ -8,46 +8,46 @@ set selection-clipboard "clipboard"
 # Dracula color theme
 #
 
-set notification-error-bg       "#ff5555" # Red
-set notification-error-fg       "#f8f8f2" # Foreground
-set notification-warning-bg     "#ffb86c" # Orange
-set notification-warning-fg     "#44475a" # Selection
-set notification-bg             "#282a36" # Background
-set notification-fg             "#f8f8f2" # Foreground
+set notification-error-bg       rgba(255,85,85,1)     # Red
+set notification-error-fg       rgba(248,248,242,1)   # Foreground
+set notification-warning-bg     rgba(255,184,108,1)   # Orange
+set notification-warning-fg     rgba(68,71,90,1)      # Selection
+set notification-bg             rgba(40,42,54,1)      # Background
+set notification-fg             rgba(248,248,242,1)   # Foreground
 
-set completion-bg               "#282a36" # Background
-set completion-fg               "#6272a4" # Comment
-set completion-group-bg         "#282a36" # Background
-set completion-group-fg         "#6272a4" # Comment
-set completion-highlight-bg     "#44475a" # Selection
-set completion-highlight-fg     "#f8f8f2" # Foreground
+set completion-bg               rgba(40,42,54,1)      # Background
+set completion-fg               rgba(98,114,164,1)    # Comment
+set completion-group-bg         rgba(40,42,54,1)      # Background
+set completion-group-fg         rgba(98,114,164,1)    # Comment
+set completion-highlight-bg     rgba(68,71,90,1)      # Selection
+set completion-highlight-fg     rgba(248,248,242,1)   # Foreground
 
-set index-bg                    "#282a36" # Background
-set index-fg                    "#f8f8f2" # Foreground
-set index-active-bg             "#44475a" # Current Line
-set index-active-fg             "#f8f8f2" # Foreground
+set index-bg                    rgba(40,42,54,1)      # Background
+set index-fg                    rgba(248,248,242,1)   # Foreground
+set index-active-bg             rgba(68,71,90,1)      # Current Line
+set index-active-fg             rgba(248,248,242,1)   # Foreground
 
-set inputbar-bg                 "#282a36" # Background
-set inputbar-fg                 "#f8f8f2" # Foreground
-set statusbar-bg                "#282a36" # Background
-set statusbar-fg                "#f8f8f2" # Foreground
+set inputbar-bg                 rgba(40,42,54,1)      # Background
+set inputbar-fg                 rgba(248,248,242,1)   # Foreground
+set statusbar-bg                rgba(40,42,54,1)      # Background
+set statusbar-fg                rgba(248,248,242,1)   # Foreground
 
 set highlight-color             rgba(255,184,108,0.5) # Orange
 set highlight-active-color      rgba(255,121,198,0.5) # Pink
 
-set default-bg                  "#282a36" # Background
-set default-fg                  "#f8f8f2" # Foreground
+set default-bg                  rgba(40,42,54,1)      # Background
+set default-fg                  rgba(248,248,242,1)   # Foreground
 
 set render-loading              true
-set render-loading-fg           "#282a36" # Background
-set render-loading-bg           "#f8f8f2" # Foreground
+set render-loading-fg           rgba(40,42,54,1)      # Background
+set render-loading-bg           rgba(248,248,242,1)   # Foreground
 
 #
 # Recolor mode settings
 #
 
-set recolor-lightcolor          "#282a36" # Background
-set recolor-darkcolor           "#f8f8f2" # Foreground
+set recolor-lightcolor          rgba(40,42,54,1)      # Background
+set recolor-darkcolor           rgba(248,248,242,1)   # Foreground
 
 #
 # Startup options


### PR DESCRIPTION
One of the recent commits in zathura removed `highlight-transparency` so the highlight defined by hex colors (like "#ffffff") became all opaque by default.

I changed the `highlight-color` and `highlight-active-color` to rgba with proper alpha value to bring back the transparency.  Moreover, in the current version of zathura's manpage, all colors are in rgba format, so I converted other dracula colors to rgba.

Here's a gif with an opaque highlight at the bottom (how it became on my machine a week ago), and a transparent one at the top (how it should be, and how this PR makes it look).
![output](https://github.com/dracula/zathura/assets/9520676/79508835-6789-4bc9-b03e-0c39ac14e995)
